### PR TITLE
Fixed behaviour for sample names containing X

### DIFF
--- a/R/top_taxa.R
+++ b/R/top_taxa.R
@@ -133,8 +133,7 @@ top_taxa <- function(ps_obj, tax_level = NULL, n_taxa = 1, grouping = NULL,
 
   # Convert to long
   ps_long <- otu_table(ps_tmp) %>%
-    data.frame(taxid = row.names(.)) %>%
-    rename_with(function(x){gsub("X", "", x)}) %>%
+    data.frame(taxid = row.names(.), check.names = F) %>%
     pivot_longer(!taxid, names_to = "sample_id", values_to = "abundance") %>%
     left_join(sample_data(ps_tmp) %>%
                 data.frame(sample_id = row.names(.)),


### PR DESCRIPTION
In a previous fix, the letter X was replaced by "" by default in sample names as a fix for samples that started with a number. This has been removed, and been replaced by no longer checking for names that are up to standards. Fix for issue #32 